### PR TITLE
Handling reference resolution (coupled with ref-res branch in go-openapi/spec)

### DIFF
--- a/fixtures/yaml/swagger/spec.yml
+++ b/fixtures/yaml/swagger/spec.yml
@@ -1,3 +1,4 @@
+swagger: "2.0"
 info:
   version: 0.1.1
   title: test 1

--- a/fixtures/yaml/swagger/spec.yml
+++ b/fixtures/yaml/swagger/spec.yml
@@ -1,0 +1,37 @@
+info:
+  version: 0.1.1
+  title: test 1
+  description: recursively following JSON references
+  contact:
+    name: Fred
+
+schemes:
+  - http
+
+consumes:
+  - application/json
+produces:
+  - application/json
+
+paths:
+  /getAll:
+    get:
+      operationId: getAll
+      parameters:
+        - name: a
+          in: body
+          description: max number of results
+          required: false
+          schema:
+            $ref: '#/definitions/a'
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/b'
+
+definitions:
+  a:
+    type: string
+  b:
+    $ref: './test3-ter-model-schema.json#/definitions/b'

--- a/fixtures/yaml/swagger/test3-ter-model-schema.json
+++ b/fixtures/yaml/swagger/test3-ter-model-schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "./test3-model-schema.json",
+  "title": "test3-model-schema",
+  "description": "Test schema responses",
+  "definitions": {
+    "b": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/spec.go
+++ b/spec.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"path/filepath"
-
 	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag"
@@ -189,7 +187,7 @@ func (d *Document) Expanded(options ...*spec.ExpandOptions) (*Document, error) {
 		expandOptions = options[0]
 	} else {
 		expandOptions = &spec.ExpandOptions{
-			RelativeBase: filepath.Dir(d.specFilePath),
+			RelativeBase: d.specFilePath,
 		}
 	}
 

--- a/spec.go
+++ b/spec.go
@@ -90,6 +90,21 @@ type Document struct {
 	raw          json.RawMessage
 }
 
+// Embedded returns a Document based on embedded specs. No analysis is required
+func Embedded(orig, flat json.RawMessage) (*Document, error) {
+	var origSpec, flatSpec spec.Swagger
+	if err := json.Unmarshal(orig, &origSpec); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(flat, &flatSpec); err != nil {
+		return nil, err
+	}
+	return &Document{
+		origSpec: &origSpec,
+		spec:     &flatSpec,
+	}, nil
+}
+
 // Spec loads a new spec document
 func Spec(path string) (*Document, error) {
 	specURL, err := url.Parse(path)

--- a/spec_test.go
+++ b/spec_test.go
@@ -655,7 +655,8 @@ const expectedExpanded = `
 `
 
 const cascadeRefExpanded = `
-{  
+{ 
+  "swagger": "2.0",
   "consumes":[  
      "application/json"
   ],

--- a/spec_test.go
+++ b/spec_test.go
@@ -45,6 +45,18 @@ func TestRegressionExpand(t *testing.T) {
 	assert.JSONEq(t, expectedExpanded, string(b))
 }
 
+func TestCascadingRefExpand(t *testing.T) {
+	swaggerFile := "fixtures/yaml/swagger/spec.yml"
+	document, err := Spec(swaggerFile)
+	assert.NoError(t, err)
+	assert.NotNil(t, document)
+	d, err := document.Expanded()
+	assert.NoError(t, err)
+	assert.NotNil(t, d)
+	b, _ := d.Spec().MarshalJSON()
+	assert.JSONEq(t, cascadeRefExpanded, string(b))
+}
+
 func TestFailsInvalidJSON(t *testing.T) {
 	_, err := Analyzed(json.RawMessage([]byte("{]")), "")
 
@@ -639,5 +651,66 @@ const expectedExpanded = `
          }
       }
    }
+}
+`
+
+const cascadeRefExpanded = `
+{  
+  "consumes":[  
+     "application/json"
+  ],
+  "produces":[  
+     "application/json"
+  ],
+  "schemes":[  
+     "http"
+  ],
+  "info":{  
+     "description":"recursively following JSON references",
+     "title":"test 1",
+     "contact":{  
+        "name":"Fred"
+     },
+     "version":"0.1.1"
+  },
+  "paths":{  
+     "/getAll":{  
+        "get":{  
+           "operationId":"getAll",
+           "parameters":[  
+              {  
+                 "description":"max number of results",
+                 "name":"a",
+                 "in":"body",
+                 "schema":{  
+                    "type":"string"
+                 }
+              }
+           ],
+           "responses":{  
+              "200":{  
+                 "description":"Success",
+                 "schema":{  
+                    "type":"array",
+                    "items":{  
+                       "type":"string"
+                    }
+                 }
+              }
+           }
+        }
+     }
+  },
+  "definitions":{  
+     "a":{  
+        "type":"string"
+     },
+     "b":{  
+        "type":"array",
+        "items":{  
+           "type":"string"
+        }
+     }
+  }
 }
 `


### PR DESCRIPTION
use full path of spec in ExpandOptions