### PR TITLE
put raw spec in Embedded()

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -100,6 +100,7 @@ func Embedded(orig, flat json.RawMessage) (*Document, error) {
 		return nil, err
 	}
 	return &Document{
+		raw:      orig,
 		origSpec: &origSpec,
 		spec:     &flatSpec,
 	}, nil


### PR DESCRIPTION
This allows the default spec middleware to return the original user-defined spec