### PR TITLE
Specfilepath retention

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -212,11 +212,12 @@ func (d *Document) Expanded(options ...*spec.ExpandOptions) (*Document, error) {
 	}
 
 	dd := &Document{
-		Analyzer: analysis.New(swspec),
-		spec:     swspec,
-		schema:   spec.MustLoadSwagger20Schema(),
-		raw:      d.raw,
-		origSpec: d.origSpec,
+		Analyzer:     analysis.New(swspec),
+		spec:         swspec,
+		specFilePath: d.specFilePath,
+		schema:       spec.MustLoadSwagger20Schema(),
+		raw:          d.raw,
+		origSpec:     d.origSpec,
 	}
 	return dd, nil
 }

--- a/spec.go
+++ b/spec.go
@@ -100,6 +100,7 @@ func Embedded(orig, flat json.RawMessage) (*Document, error) {
 		return nil, err
 	}
 	return &Document{
+		raw:      orig,
 		origSpec: &origSpec,
 		spec:     &flatSpec,
 	}, nil


### PR DESCRIPTION
specFilepath should be retained even after expanded because validate uses it
fixes go-openapi/validate#41