### PR TITLE
fix(spec): rendering a Pristine document should ensure raw is up to date

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -248,7 +248,8 @@ func (d *Document) ResetDefinitions() *Document {
 
 // Pristine creates a new pristine document instance based on the input data
 func (d *Document) Pristine() *Document {
-	dd, _ := Analyzed(d.Raw(), d.Version())
+	raw, _ := json.Marshal(d.Spec())
+	dd, _ := Analyzed(raw, d.Version())
 	dd.pathLoader = d.pathLoader
 	dd.specFilePath = d.specFilePath
 


### PR DESCRIPTION
This PR makes sure that whenever rendering a Pristine document (e.g. to create a clean document from a fresh clone), the raw root doc is up-to-date.

In go-swagger, we modify the spec (e.g. with flatten, expand, ...) and the internal state of the spec document may sometimes need a clean Document to be reconstructed.

* contributes go-swagger/go-swagger#2346